### PR TITLE
Update rails to be a dev dependency

### DIFF
--- a/grape_on_rails_routes.gemspec
+++ b/grape_on_rails_routes.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", ">=3.1.1"
+  s.add_development_dependency "rails", ">=3.1.1"
   s.add_development_dependency "rspec"
   s.add_development_dependency "grape"
 end


### PR DESCRIPTION
For project that does not have `rails` as a dependency (but have `railties`)